### PR TITLE
Fix on/off value mapping in Keithley2182A driver

### DIFF
--- a/src/qcodes_contrib_drivers/drivers/Tektronix/Keithley_2182A.py
+++ b/src/qcodes_contrib_drivers/drivers/Tektronix/Keithley_2182A.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 
 # Create standard on/off value mapping
-on_off_vals = create_on_off_val_mapping(on_val="ON", off_val="OFF")
+on_off_vals = create_on_off_val_mapping(on_val="1", off_val="0")
 
 
 class ApertureTimeValidator(Validator):

--- a/src/qcodes_contrib_drivers/sims/Keithley_2182A.yaml
+++ b/src/qcodes_contrib_drivers/sims/Keithley_2182A.yaml
@@ -43,9 +43,9 @@ devices:
         specs:
           type: float
 
-      # Auto range setting - use ON/OFF strings
+      # Auto range setting - use 1/0 strings
       auto_range:
-        default: "ON"
+        default: "1"
         getter:
           q: "SENS:VOLT:RANG:AUTO?"
           r: "{}"
@@ -53,7 +53,7 @@ devices:
           q: "SENS:VOLT:RANG:AUTO {}"
         specs:
           type: str
-          valid: ["ON", "OFF"]
+          valid: ["1", "0"]
 
       # NPLC (Number of Power Line Cycles)
       nplc:
@@ -100,9 +100,9 @@ devices:
           type: float
 
 
-      # Display enabled - use ON/OFF strings
+      # Display enabled - use 1/0 strings
       display_enabled:
-        default: "ON"
+        default: "1"
         getter:
           q: "DISP:ENAB?"
           r: "{}"
@@ -110,12 +110,12 @@ devices:
           q: "DISP:ENAB {}"
         specs:
           type: str
-          valid: ["ON", "OFF"]
+          valid: ["1", "0"]
 
 
-      # Analog filter - use ON/OFF strings
+      # Analog filter - use 1/0 strings
       analog_filter:
-        default: "OFF"
+        default: "0"
         getter:
           q: "SENS:VOLT:DC:LPAS?"
           r: "{}"
@@ -123,11 +123,11 @@ devices:
           q: "SENS:VOLT:DC:LPAS {}"
         specs:
           type: str
-          valid: ["ON", "OFF"]
+          valid: ["1", "0"]
 
-      # Digital filter - use ON/OFF strings
+      # Digital filter - use 1/0 strings
       digital_filter:
-        default: "OFF"
+        default: "0"
         getter:
           q: "SENS:VOLT:DC:DFIL?"
           r: "{}"
@@ -135,11 +135,11 @@ devices:
           q: "SENS:VOLT:DC:DFIL {}"
         specs:
           type: str
-          valid: ["ON", "OFF"]
+          valid: ["1", "0"]
 
-      # Auto-zero - use ON/OFF strings
+      # Auto-zero - use 1/0 strings
       auto_zero:
-        default: "ON"
+        default: "1"
         getter:
           q: "SYST:AZER?"
           r: "{}"
@@ -147,7 +147,7 @@ devices:
           q: "SYST:AZER {}"
         specs:
           type: str
-          valid: ["ON", "OFF"]
+          valid: ["1", "0"]
 
       # Line frequency detection
       line_frequency:


### PR DESCRIPTION
This pull request updates the value mapping for the standard on/off states in the `Keithley_2182A.py` driver. The change ensures that the driver uses `"1"` and `"0"` instead of `"ON"` and `"OFF"` for on/off values, likely to match the instrument's expected command format.

* Updated the `on_off_vals` mapping in `Keithley_2182A.py` to use `"1"` for on and `"0"` for off, instead of `"ON"` and `"OFF"`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected on/off value mapping for the Keithley 2182A to use numeric "1"/"0" for improved hardware compatibility and control accuracy.
  * Aligned device defaults and valid option strings in simulators to numeric "1"/"0" for consistent behavior between real and simulated instruments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->